### PR TITLE
DRT-54: Request audio focus when video playback starts

### DIFF
--- a/android/src/main/java/jp/manse/util/AudioFocusManager.java
+++ b/android/src/main/java/jp/manse/util/AudioFocusManager.java
@@ -1,0 +1,61 @@
+package jp.manse.util;
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.support.annotation.NonNull;
+
+public class AudioFocusManager {
+
+    AudioManager audioManager;
+    // The AudioFocusChangeListerner that will be associated with audioManager focus request
+    AudioManager.OnAudioFocusChangeListener onAudioFocusChangeListener;
+    boolean mHaveAudioFocus = false;
+    // The external listener of the changes (player)
+    AudioFocusChangedListener listener;
+
+    public AudioFocusManager(@NonNull Context context) {
+        audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        onAudioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+                mHaveAudioFocus = focusChange > 0;
+                onAudioStateChanged();
+            }
+        };
+
+    }
+
+    public void registerListener(AudioFocusChangedListener listener) {
+        this.listener = listener;
+    }
+
+    public void unregisterListener() {
+        this.listener = null;
+    }
+
+    public void requestFocus() {
+        // If it already has focus then return, otherwise, request the focus with the onAudioFocusChangeListener
+        if (mHaveAudioFocus) {
+            return;
+        }
+        audioManager.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN);
+    }
+
+    public void abandonFocus() {
+        if (mHaveAudioFocus) {
+            audioManager.abandonAudioFocus(onAudioFocusChangeListener);
+        }
+    }
+
+    private void onAudioStateChanged() {
+        // Inform the AudioFocusChangedListener (the player) of the focus change
+        if (this.listener != null) {
+            this.listener.audioFocusChanged(mHaveAudioFocus);
+        }
+    }
+
+    public interface AudioFocusChangedListener {
+        void audioFocusChanged(boolean hasFocus);
+    }
+}


### PR DESCRIPTION
Implement AudioFocusManager which stops all background audio when the video starts playing. It also pauses the video when it looses focus (Resuming a music app from the notification slide for example)