### PR TITLE
DRT-66: Resume video playback if connection breaks

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="jp.manse">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/android/src/main/java/jp/manse/BrightcovePlayerManager.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerManager.java
@@ -33,6 +33,7 @@ public class BrightcovePlayerManager extends SimpleViewManager<BrightcovePlayerV
     public static final String EVENT_BEFORE_EXIT_FULLSCREEN = "event_before_exit_fullscreen";
     public static final String EVENT_ENTER_FULLSCREEN = "event_enter_fullscreen";
     public static final String EVENT_EXIT_FULLSCREEN = "event_exit_fullscreen";
+    public static final String EVENT_NETWORK_CONNECTIVITY_CHANGED = "event_network_connectivity_changed";
 
     private ReactApplicationContext applicationContext;
 
@@ -163,6 +164,7 @@ public class BrightcovePlayerManager extends SimpleViewManager<BrightcovePlayerV
         map.put(EVENT_ENTER_FULLSCREEN, (Object) MapBuilder.of("registrationName", "onEnterFullscreen"));
         map.put(EVENT_EXIT_FULLSCREEN, (Object) MapBuilder.of("registrationName", "onExitFullscreen"));
         map.put(EVENT_ERROR, (Object) MapBuilder.of("registrationName", "onError"));
+        map.put(EVENT_NETWORK_CONNECTIVITY_CHANGED, (Object) MapBuilder.of("registrationName", "onNetworkConnectivityChange"));
         return map;
     }
 }

--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -538,6 +538,16 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
     }
 
     @Override
+    protected void onDetachedFromWindow() {
+        // For safety, clear listeners in onDetachedFromWindow too since when the back button or home toolbar button are
+        // clicked, onHostPause does not get executed
+        super.onDetachedFromWindow();
+        // Unregister from audio focus changes when the screen goes in the background
+        audioFocusManager.unregisterListener();
+        unregisterConnectivityChange();
+    }
+
+    @Override
     public void onHostDestroy() {
         this.playerVideoView.destroyDrawingCache();
         this.playerVideoView.clear();

--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -1,12 +1,8 @@
 package jp.manse;
 
-import android.content.Context;
+import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.media.AudioAttributes;
-import android.media.AudioFocusRequest;
-import android.media.AudioManager;
-import android.media.MediaPlayer;
 import android.support.v4.view.ViewCompat;
 import android.util.Log;
 import android.view.Choreographer;
@@ -51,8 +47,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import jp.manse.util.AudioFocusManager;
+import jp.manse.util.NetworkChangeReceiver;
+import jp.manse.util.NetworkUtil;
 
-public class BrightcovePlayerView extends RelativeLayout implements LifecycleEventListener, AudioFocusManager.AudioFocusChangedListener {
+public class BrightcovePlayerView extends RelativeLayout implements LifecycleEventListener,
+        AudioFocusManager.AudioFocusChangedListener, NetworkChangeReceiver.NetworkChangeListener {
     private ThemedReactContext context;
     private ReactApplicationContext applicationContext;
     private BrightcoveExoPlayerVideoView playerVideoView;
@@ -74,6 +73,9 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 	private static final int SEEK_AMOUNT = 10000; // In milliseconds
     private static final TrackSelection.Factory FIXED_FACTORY = new FixedTrackSelection.Factory();
     private AudioFocusManager audioFocusManager;
+    private NetworkChangeReceiver networkChangeReceiver;
+    private boolean isNetworkForcedPause = false;
+    private boolean isRegisteredConnectivityChanged = false;
 
     public BrightcovePlayerView(ThemedReactContext context, ReactApplicationContext applicationContext) {
         super(context);
@@ -103,6 +105,10 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         // Create AudioFocusManager instance and register BrightcovePlayerView as a listener
         this.audioFocusManager = new AudioFocusManager(this.context);
         this.audioFocusManager.registerListener(this);
+
+        // Create Network Change Broadcast receiver and register this class to listen to network status changes
+        this.networkChangeReceiver = new NetworkChangeReceiver();
+        registerConnectivityChange();
 
         EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
@@ -521,12 +527,14 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
     public void onHostResume() {
 	    // Register to audio focus changes when the screen resumes
 	    audioFocusManager.registerListener(this);
+        registerConnectivityChange();
     }
 
     @Override
     public void onHostPause() {
         // Unregister from audio focus changes when the screen goes in the background
         audioFocusManager.unregisterListener();
+        unregisterConnectivityChange();
     }
 
     @Override
@@ -565,9 +573,64 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 
     @Override
     public void audioFocusChanged(boolean hasFocus) {
-	    // Pasue the video when it looses focus
+	    // Pause the video when it looses focus
 	    if (!hasFocus && playerVideoView.isPlaying()) {
 	        playerVideoView.pause();
         }
+    }
+
+    @Override
+    public void onConnected() {
+        // When network is regained, if this is not and offline video (VideoToken check), set the network forced pause flag to false and start playback 
+        if (isNetworkForcedPause && (videoToken == null || videoToken.isEmpty())) {
+            isNetworkForcedPause = false;
+            onNetworkConnectivityChange(NetworkUtil.STATUS_RECONNECTED);
+            this.playerVideoView.start();
+        }
+    }
+
+    @Override
+    public void onDisconnected() {
+        // When network is disconnected, if this is not and offline video (VideoToken check), then set a flag that the video will be forcebly paused when 
+        // the playback of the remaining buffered part of the video ends
+        if (videoToken == null || videoToken.isEmpty()) {
+            isNetworkForcedPause = true;
+            onNetworkConnectivityChange(NetworkUtil.STATUS_STALLED);
+        }
+    }
+
+    private void registerConnectivityChange() {
+        // Register this class to listen to network change events
+        // Register the network change receiver
+        if (!isRegisteredConnectivityChanged) {
+            isRegisteredConnectivityChanged = true;
+            this.networkChangeReceiver.registerListener(this);
+            IntentFilter intentFilter = new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE");
+            this.context.registerReceiver(this.networkChangeReceiver, intentFilter);
+        }
+    }
+
+    private void unregisterConnectivityChange() {
+        // Unregister this class from listenning to network change events
+        // Unregister the network change receiver
+        if (isRegisteredConnectivityChanged) {
+            isRegisteredConnectivityChanged = false;
+            this.networkChangeReceiver.unregisterListener();
+            this.context.unregisterReceiver(this.networkChangeReceiver);
+        }
+    }
+
+    private void onNetworkConnectivityChange(String networkStatus) {
+        // Send an event to React with the network status
+        WritableMap event = Arguments.createMap();
+        event.putString("status", networkStatus);
+        ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
+        reactContext
+                .getJSModule(RCTEventEmitter.class)
+                .receiveEvent(
+                        BrightcovePlayerView.this.getId(),
+                        BrightcovePlayerManager.EVENT_NETWORK_CONNECTIVITY_CHANGED,
+                        event
+                );
     }
 }

--- a/android/src/main/java/jp/manse/util/NetworkChangeReceiver.java
+++ b/android/src/main/java/jp/manse/util/NetworkChangeReceiver.java
@@ -1,0 +1,44 @@
+package jp.manse.util;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class NetworkChangeReceiver extends BroadcastReceiver {
+
+    private NetworkChangeListener listener;
+
+    @Override
+    public void onReceive(final Context context, final Intent intent) {
+
+        int status = NetworkUtil.getConnectivityStatus(context);
+        Log.e("NetworkChangeReceiver", "The network status is " + status);
+        if ("android.net.conn.CONNECTIVITY_CHANGE".equals(intent.getAction())) {
+            if (status == NetworkUtil.NETWORK_STATUS_NOT_CONNECTED) {
+                Log.e("NetworkChangeReceiver", "Not connected");
+                if (listener != null) {
+                    listener.onDisconnected();
+                }
+            } else {
+                Log.e("NetworkChangeReceiver", "Is connected");
+                if (listener != null) {
+                    listener.onConnected();
+                }
+            }
+        }
+    }
+
+    public void registerListener(NetworkChangeListener listener) {
+        this.listener = listener;
+    }
+
+    public void unregisterListener() {
+        this.listener = null;
+    }
+
+    public interface NetworkChangeListener {
+        void onConnected();
+        void onDisconnected();
+    }
+}

--- a/android/src/main/java/jp/manse/util/NetworkUtil.java
+++ b/android/src/main/java/jp/manse/util/NetworkUtil.java
@@ -1,0 +1,31 @@
+package jp.manse.util;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+public class NetworkUtil {
+    public static final int TYPE_WIFI = 1;
+    public static final int TYPE_MOBILE = 2;
+    public static final int TYPE_NOT_CONNECTED = 0;
+    public static final int NETWORK_STATUS_NOT_CONNECTED = 0;
+    public static final int NETWORK_STATUS_WIFI = 1;
+    public static final int NETWORK_STATUS_MOBILE = 2;
+    public static final String STATUS_RECONNECTED = "reconnected";
+    public static final String STATUS_STALLED = "stalled";
+
+
+    public static int getConnectivityStatus(Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        if (null != activeNetwork) {
+            if(activeNetwork.getType() == ConnectivityManager.TYPE_WIFI)
+                return TYPE_WIFI;
+
+            if(activeNetwork.getType() == ConnectivityManager.TYPE_MOBILE)
+                return TYPE_MOBILE;
+        }
+        return TYPE_NOT_CONNECTED;
+    }
+}


### PR DESCRIPTION
I created a new branch for this issue "DRT-66-1" instead of the old one "DRT-66" since changes were added to the development branches and I did not want to add any rebase/merge commits to history. I am closing the other outdated PR.

Details are in commit messages, the last commit solves another weird React-Native behavior.