### PR TITLE
Add native Android overlay

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -3,12 +3,12 @@ package jp.manse;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.support.constraint.ConstraintLayout;
 import android.support.v4.view.ViewCompat;
 import android.util.Log;
 import android.view.Choreographer;
 import android.view.SurfaceView;
 import android.view.View;
-import android.widget.RelativeLayout;
 
 import com.brightcove.player.display.ExoPlayerVideoDisplayComponent;
 import com.brightcove.player.edge.Catalog;
@@ -50,7 +50,7 @@ import jp.manse.util.AudioFocusManager;
 import jp.manse.util.NetworkChangeReceiver;
 import jp.manse.util.NetworkUtil;
 
-public class BrightcovePlayerView extends RelativeLayout implements LifecycleEventListener,
+public class BrightcovePlayerView extends ConstraintLayout implements LifecycleEventListener,
         AudioFocusManager.AudioFocusChangedListener, NetworkChangeReceiver.NetworkChangeListener {
     private ThemedReactContext context;
     private ReactApplicationContext applicationContext;
@@ -83,11 +83,9 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         this.applicationContext = applicationContext;
         this.applicationContext.addLifecycleEventListener(this);
         this.setBackgroundColor(Color.BLACK);
-
-        this.playerVideoView = new BrightcoveExoPlayerVideoView(this.context.getCurrentActivity());
-
-        this.addView(this.playerVideoView);
-        this.playerVideoView.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+        // Inflate the BrightcovePlayerView with the custom layout
+        inflate(this.context.getCurrentActivity(), R.layout.brightcove_player_view, this);
+        this.playerVideoView = findViewById(R.id.bc_player_view);
         this.playerVideoView.finishInitialization();
         this.mediaController = new BrightcoveMediaController(this.playerVideoView);
         this.playerVideoView.setMediaController(this.mediaController);
@@ -109,6 +107,14 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         // Create Network Change Broadcast receiver and register this class to listen to network status changes
         this.networkChangeReceiver = new NetworkChangeReceiver();
         registerConnectivityChange();
+
+        findViewById(R.id.native_overlay_button).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                v.setVisibility(GONE);
+                BrightcovePlayerView.this.findViewById(R.id.native_overlay).setVisibility(GONE);
+            }
+        });
 
         EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {

--- a/android/src/main/res/layout/brightcove_player_view.xml
+++ b/android/src/main/res/layout/brightcove_player_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <com.brightcove.player.view.BrightcoveExoPlayerVideoView
+        android:id="@+id/bc_player_view"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </com.brightcove.player.view.BrightcoveExoPlayerVideoView>
+    <View
+        android:id="@+id/native_overlay"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:background="@color/green_almost_opaque"/>
+    <Button
+        android:id="@+id/native_overlay_button"
+        app:layout_constraintStart_toStartOf="@id/native_overlay"
+        app:layout_constraintTop_toTopOf="@id/native_overlay"
+        app:layout_constraintEnd_toEndOf="@id/native_overlay"
+        app:layout_constraintBottom_toBottomOf="@id/native_overlay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        android:text="Do not click"/>
+</android.support.constraint.ConstraintLayout>

--- a/example/components/video-header.js
+++ b/example/components/video-header.js
@@ -56,12 +56,12 @@ export default class VideoHeader extends Component {
 					// }}
 				>
 					{/* This overlay is the child of the BCPlayer */}
-					<Overlay style={styles.overlay} visible={this.state.overlayVisible}>
+					{/* <Overlay nativeID={'my_overlay'} style={styles.overlay} visible={this.state.overlayVisible}>
 						<Button
 							title="Close me"
 							style={styles.buttonText}
 							onPress={() => { this.setState({ overlayVisible: false })}} />
-					</Overlay>
+					</Overlay> */}
 
 				</BCPlayer>
 


### PR DESCRIPTION
Instead of creating and adding the views programmatically, now we can add them inside the layout file (brightcove_player_view.xml) which gets inflated. This conforms more with the Android best practices