### PR TITLE
Only call loadVideo when all the needed metadata is ready

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -333,7 +333,6 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
     public void setPlayerId(String playerId) {
         this.playerId = playerId;
 		this.analytics.setDestination("bcsdk://" + playerId);
-        this.loadVideo();
     }
 
     public void setVideoId(String videoId) {
@@ -350,7 +349,9 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 
     public void setVideoToken(String videoToken) {
         this.videoToken = videoToken;
-        this.loadVideo();
+        if (videoToken == null || videoToken.isEmpty()) {
+            this.loadVideo();
+        }
     }
 
     public void setAutoPlay(boolean autoPlay) {
@@ -488,7 +489,7 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 
         this.catalog = new Catalog(this.playerVideoView.getEventEmitter(), this.accountId, this.policyKey);
 
-		if (this.accountId != null) {
+		if (this.accountId != null && this.policyKey != null) {
 			if (this.videoId != null) {
 				this.catalog.findVideoByID(this.videoId, listener);
 			} else if (this.referenceId != null) {


### PR DESCRIPTION
LoadVideo was being called when multiple meta-data is set causing video impression to be sent multiple times against one play event, causing the view rate to drop to 50%.
No need to call loadVideo after setting the playerId, the important thing is that the playerId is set to analytics
No need to call loadVideo after setting the videoToken if it is null
Perform check on Policy Key before fetching the video